### PR TITLE
(chore) Add project structure

### DIFF
--- a/UniversalUnitConverters.sln
+++ b/UniversalUnitConverters.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalUnitConverters", "src\UniversalUnitConverters\UniversalUnitConverters.csproj", "{D6C2EA13-1324-4252-BB8A-84BEB3EF8334}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalUnitConverters.Tests", "tests\UniversalUnitConverters.Tests\UniversalUnitConverters.Tests.csproj", "{9DA2D391-37FE-43FA-85A4-152D376854F8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D6C2EA13-1324-4252-BB8A-84BEB3EF8334}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6C2EA13-1324-4252-BB8A-84BEB3EF8334}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6C2EA13-1324-4252-BB8A-84BEB3EF8334}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6C2EA13-1324-4252-BB8A-84BEB3EF8334}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DA2D391-37FE-43FA-85A4-152D376854F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DA2D391-37FE-43FA-85A4-152D376854F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DA2D391-37FE-43FA-85A4-152D376854F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DA2D391-37FE-43FA-85A4-152D376854F8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8FEC5151-2824-4F6E-88DB-78770BD5C087}
+	EndGlobalSection
+EndGlobal

--- a/src/UniversalUnitConverters/UniversalUnitConverters.csproj
+++ b/src/UniversalUnitConverters/UniversalUnitConverters.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/tests/UniversalUnitConverters.Tests/UniversalUnitConverters.Tests.csproj
+++ b/tests/UniversalUnitConverters.Tests/UniversalUnitConverters.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\UniversalUnitConverters\UniversalUnitConverters.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- Added `UniversalUnitConverters` library project (.NET Standard 2.0) under `src` folder
- Added `UniversalUnitConverters.Tests` xUnit test project (.NET 8) under `tests` folder.
